### PR TITLE
Fix for wrong node processing

### DIFF
--- a/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/BuildKotlinJsAction.kt
+++ b/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/BuildKotlinJsAction.kt
@@ -28,6 +28,7 @@ class BuildKotlinJsAction(
 
         projectCopier.copy(project)
         substitutor.substitute(psiElement, project)
+        // fixme: by this moment, everything MUST be synced - file system should have main method substituted
         builder.build(project)
 
         openBrowserWindow(project)

--- a/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/JsPreviewRunLineMarkerContributor.kt
+++ b/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/JsPreviewRunLineMarkerContributor.kt
@@ -7,7 +7,7 @@ import com.sanyavertolet.kotlinjspreview.utils.isValOfPropertyAnnotatedWith
 
 class JsPreviewRunLineMarkerContributor : RunLineMarkerContributor() {
     override fun getInfo(element: PsiElement): Info? = if (element.isValOfPropertyAnnotatedWith("JsPreview")) {
-        Info(AllIcons.Actions.Execute, { "Run preview" }, BuildKotlinJsAction(element))
+        Info(AllIcons.Actions.Execute, { "Run preview" }, BuildKotlinJsAction(element.parent))
     } else {
         null
     }

--- a/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/builder/GradleBuilder.kt
+++ b/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/builder/GradleBuilder.kt
@@ -11,13 +11,12 @@ import com.sanyavertolet.kotlinjspreview.config.PluginConfig
 import com.sanyavertolet.kotlinjspreview.utils.getPathOrException
 import com.sanyavertolet.kotlinjspreview.task.JsPreviewNotifierCallback
 import org.jetbrains.kotlin.idea.configuration.GRADLE_SYSTEM_ID
-import org.jetbrains.kotlin.idea.util.application.runWriteAction
 import java.util.*
 
 class GradleBuilder : Builder {
     private val config: PluginConfig = PluginConfig.getInstance()
 
-    override fun build(project: Project) = runWriteAction { runBuildTaskForTempProject(project) }
+    override fun build(project: Project) = runBuildTaskForTempProject(project)
 
     private fun runBuildTaskForTempProject(project: Project) = ExternalSystemUtil.runTask(
         getBuildSettings(project),

--- a/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/copier/SimpleProjectCopier.kt
+++ b/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/copier/SimpleProjectCopier.kt
@@ -1,35 +1,52 @@
 package com.sanyavertolet.kotlinjspreview.copier
 
+import com.intellij.openapi.application.runUndoTransparentWriteAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.sanyavertolet.kotlinjspreview.config.PluginConfig
 import com.sanyavertolet.kotlinjspreview.utils.BUILD_DIR
 import com.sanyavertolet.kotlinjspreview.utils.NO_PROJECT_DIR
-import com.sanyavertolet.kotlinjspreview.config.PluginConfig
 import com.sanyavertolet.kotlinjspreview.utils.createChildDirectoryIfNotCreated
 import com.sanyavertolet.kotlinjspreview.utils.orException
-import org.apache.commons.io.FileUtils
-import org.apache.commons.io.filefilter.FileFilterUtils
 import org.jetbrains.kotlin.idea.util.application.runWriteAction
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
 
 class SimpleProjectCopier: ProjectCopier {
     private val config: PluginConfig = PluginConfig.getInstance()
 
     override fun copy(project: Project) {
         val projectDir = project.guessProjectDir().orException { NO_PROJECT_DIR }
-        val tempDir = runWriteAction { createTempDir(project) }
-        runWriteAction { copyFilesRecursively(projectDir, tempDir) }
+        val tempDir = createTempDir(project)
+        runWriteAction { copyProjectRecursively(projectDir.path, tempDir.path) }
     }
 
-    private fun copyFilesRecursively(source: VirtualFile, dist: VirtualFile) {
-        val dirFilter = FileFilterUtils.notFileFilter(
-            FileFilterUtils.or(
-                *config.copyIgnoreFileNames.map { FileFilterUtils.nameFileFilter(it) }.toTypedArray()
-            )
-        )
-        FileUtils.copyDirectory(File(source.path), File(dist.path), dirFilter)
+    private fun copyProjectRecursively(sourceDir: String, destDir: String) {
+        val srcDir = File(sourceDir)
+        val dstDir = File(destDir)
+        if (srcDir.isDirectory()) {
+            if (!dstDir.exists()) {
+                dstDir.mkdir()
+            }
+            val children = srcDir.list()
+            if (children != null) {
+                for (child in children) {
+                    if (!config.copyIgnoreFileNames.contains(child)) {
+                        copyProjectRecursively(File(srcDir, child).path, File(dstDir, child).path)
+                    }
+                }
+            }
+        } else {
+            val sourcePath: Path = Paths.get(srcDir.absolutePath)
+            val destPath: Path = Paths.get(dstDir.absolutePath)
+            Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING)
+        }
     }
 
     private fun createTempDir(project: Project): VirtualFile {
@@ -39,7 +56,9 @@ class SimpleProjectCopier: ProjectCopier {
         val tempDir = LocalFileSystem.getInstance().refreshAndFindFileByPath(tempDirPath)
 
         return tempDir?.takeIf { it.exists() }
-            ?: projectBaseDir.createChildDirectoryIfNotCreated(BUILD_DIR)
-                .createChildDirectoryIfNotCreated(config.tempProjectDirName)
+            ?: runUndoTransparentWriteAction {
+                projectBaseDir.createChildDirectoryIfNotCreated(BUILD_DIR)
+                    .createChildDirectoryIfNotCreated(config.tempProjectDirName)
+            }
     }
 }


### PR DESCRIPTION
### What's done:
 * Now processing parent node of `val` keyword - the one that has `Property` type
 * Removed useless `runWriteAction`