### PR TITLE
Plugin publishing configuration

### DIFF
--- a/gradle/plugins/src/main/kotlin/com/sanyavertolet/kotlinjspreview/buildutils/FileUtils.kt
+++ b/gradle/plugins/src/main/kotlin/com/sanyavertolet/kotlinjspreview/buildutils/FileUtils.kt
@@ -1,0 +1,20 @@
+
+package com.sanyavertolet.kotlinjspreview.buildutils
+
+import org.gradle.api.Project
+import java.io.File
+
+fun readFromFile(filePath: String?) = filePath?.let { File(it) }
+    ?.takeIf { it.exists() }
+    ?.readLines()
+    ?.joinToString("\n")
+
+fun readFromFileOrEnv(
+    filePath: String?,
+    envName: String,
+): String? = readFromFile(filePath) ?: System.getenv(envName)
+
+fun Project.readFromPropertyOrEnv(
+    propertyName: String,
+    envName: String,
+) = readFromFileOrEnv(findProperty(propertyName) as String?, envName)

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.sanyavertolet.kotlinjspreview.buildutils.configureSigning
+import com.sanyavertolet.kotlinjspreview.buildutils.readFromPropertyOrEnv
 
 plugins {
     alias(libs.plugins.intellij)
@@ -33,18 +34,22 @@ tasks {
     }
 
     patchPluginXml {
+
         sinceBuild.set("223")
         untilBuild.set("232.*")
+        version.set(project.version.toString())
     }
 
+    val jetbrainsMarketplaceToken = findProperty("jb.token") as String? ?: System.getenv("JB_TOKEN")
+
     signPlugin {
-        certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
-        privateKey.set(System.getenv("PRIVATE_KEY"))
-        password.set(System.getenv("PRIVATE_KEY_PASSWORD"))
+        certificateChain.set(readFromPropertyOrEnv("jb.chain", "CERTIFICATE_CHAIN"))
+        privateKey.set(readFromPropertyOrEnv("jb.private", "PRIVATE_KEY"))
+        password.set(readFromPropertyOrEnv("jb.password", "PRIVATE_KEY_PASSWORD"))
     }
 
     publishPlugin {
-        token.set(System.getenv("PUBLISH_TOKEN"))
+        token.set(jetbrainsMarketplaceToken)
     }
 }
 

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -5,7 +5,6 @@
     <description>An attempt to provide Kotlin/JS previews</description>
     <change-notes>Initial release of the plugin.</change-notes>
     <vendor email="lxnfrolov@gmail.com" url="https://www.github.com/sanyavertolet">sanyavertolet</vendor>
-    <version>0.1.0</version>
 
     <depends>com.intellij.modules.platform</depends>
     <depends>org.jetbrains.kotlin</depends>


### PR DESCRIPTION
### What's done:
 * Replaced hardcoded plugin version with `project.version`, calculated by `Reckon`
 * Added plugin publishing configuration