### PR TITLE
Fix plugin analysis problems

### DIFF
--- a/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/BuildKotlinJsAction.kt
+++ b/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/BuildKotlinJsAction.kt
@@ -11,7 +11,6 @@ import com.sanyavertolet.kotlinjspreview.copier.ProjectCopier
 import com.sanyavertolet.kotlinjspreview.copier.VfsProjectCopier
 import com.sanyavertolet.kotlinjspreview.substituror.AstSubstitutor
 import com.sanyavertolet.kotlinjspreview.substituror.Substitutor
-import org.jetbrains.kotlin.idea.util.application.runReadAction
 
 /**
  * @JsPreview
@@ -38,6 +37,6 @@ class BuildKotlinJsAction(
 
     private fun openBrowserWindow(project: Project) {
         val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(PreviewToolWindowFactory.ID)
-        runReadAction { toolWindow?.activate(null) }
+        toolWindow?.activate(null)
     }
 }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -6,6 +6,7 @@
     <change-notes>Initial release of the plugin.</change-notes>
     <vendor email="lxnfrolov@gmail.com" url="https://www.github.com/sanyavertolet">sanyavertolet</vendor>
 
+    <depends>com.intellij.modules.java</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends>org.jetbrains.kotlin</depends>
 


### PR DESCRIPTION
### What's done:
 * Added `com.intellij.modules.java` to plugin dependencies
 * Removed `runReadAction` from `BuildKotlinJsAction#openBrowserWindow`