### PR TITLE
RootWrapperCountsInspection

### DIFF
--- a/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/inspection/RootWrapperCountsInspection.kt
+++ b/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/inspection/RootWrapperCountsInspection.kt
@@ -1,0 +1,37 @@
+package com.sanyavertolet.kotlinjspreview.inspection
+
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiFile
+import com.sanyavertolet.kotlinjspreview.utils.getUsages
+import org.jetbrains.kotlin.idea.codeinsight.api.classic.inspections.AbstractKotlinInspection
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+
+class RootWrapperCountsInspection : AbstractKotlinInspection() {
+    override fun checkFile(
+        file: PsiFile,
+        manager: InspectionManager,
+        isOnTheFly: Boolean,
+    ): Array<ProblemDescriptor> {
+        val problemsHolder = ProblemsHolder(manager, file, isOnTheFly)
+        file.collectDescendantsOfType<KtAnnotationEntry> { annotation ->
+            annotation.shortName?.asString() == ROOT_WRAPPER_SHORT_NAME
+        }
+            .filter { it.getUsages(file.project).size > 1 }
+            .map { annotation ->
+                problemsHolder.registerProblem(
+                    annotation,
+                    "Several $ROOT_WRAPPER_SHORT_NAME annotation usages were found: there should be only one usage of $ROOT_WRAPPER_SHORT_NAME",
+                    ProblemHighlightType.GENERIC_ERROR,
+                )
+            }
+        return problemsHolder.resultsArray
+    }
+
+    companion object {
+        private const val ROOT_WRAPPER_SHORT_NAME = "RootWrapper"
+    }
+}

--- a/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/utils/PsiUtils.kt
+++ b/plugin/src/main/kotlin/com/sanyavertolet/kotlinjspreview/utils/PsiUtils.kt
@@ -3,9 +3,13 @@
  */
 package com.sanyavertolet.kotlinjspreview.utils
 
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import org.jetbrains.kotlin.idea.base.psi.kotlinFqName
+import org.jetbrains.kotlin.idea.base.util.projectScope
+import org.jetbrains.kotlin.idea.stubindex.KotlinAnnotationsIndex
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtProperty
 
 /**
@@ -47,3 +51,17 @@ fun PsiElement.isValOfPropertyAnnotatedWith(
  * @return fully-qualified name of [this] as [KtProperty]
  */
 fun PsiElement.getIdentifier() = (this as KtProperty).kotlinFqName
+
+/**
+ * Get usages of [this] [KtAnnotationEntry] in [project]
+ *
+ * @param project current [Project]
+ * @return [Collection] of usages or [emptyList] if none was found
+ */
+fun KtAnnotationEntry.getUsages(project: Project) = shortName?.let { annotationName ->
+    KotlinAnnotationsIndex.get(
+        annotationName.asString(),
+        project,
+        project.projectScope(),
+    )
+} ?: emptyList()

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -70,5 +70,17 @@
                 shortName="RootWrapperFirstArgumentInspection"
                 runForWholeFile="true"
         />
+
+        <localInspection
+            language="kotlin"
+            groupPath="Kotlin"
+            groupBundle="messages.InspectionsBundle"
+            groupKey="group.names.probable.bugs"
+            enabledByDefault="true"
+            implementationClass="com.sanyavertolet.kotlinjspreview.inspection.RootWrapperCountsInspection"
+            displayName="RootWrapper count"
+            shortName="RootWrapperCountsInspection"
+            runForWholeFile="true"
+        />
     </extensions>
 </idea-plugin>

--- a/plugin/src/main/resources/inspectionDescriptions/RootWrapperCountsInspection.html
+++ b/plugin/src/main/resources/inspectionDescriptions/RootWrapperCountsInspection.html
@@ -1,0 +1,9 @@
+<html>
+<body>
+Detects several @RootWrapper annotation usages and highlights them as errors.
+<p>
+    There should be only one method annotated with @RootWrapper annotation as the plugin logic depends on single root wrapper.
+</p>
+<!-- tooltip end -->
+</body>
+</html>

--- a/plugin/src/main/resources/inspectionDescriptions/RootWrapperFirstArgumentInspection.html
+++ b/plugin/src/main/resources/inspectionDescriptions/RootWrapperFirstArgumentInspection.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Checks that the first argument of root wrapper is has a type of `react.FC`.
+</body>
+</html>


### PR DESCRIPTION
### What's done:
 * Added `RootWrapperCountsInspection` that provides detection of several `@RootWrapper` usages
 * Added `RootWrapperCountsInspection.html`
 * Added `RootWrapperFirstArgumentInspection.html`